### PR TITLE
micah/52/update pipeline script

### DIFF
--- a/update-pipeline-blocks-graph.sh
+++ b/update-pipeline-blocks-graph.sh
@@ -1,0 +1,35 @@
+#
+# now let's generate an updated readme-blocks-graph.json
+#
+
+#
+# first we copy over the blocks metadata from blockbuilder-search-index
+#
+BLOCKBUILDER_SEARCH_INDEX_HOME="/Users/m/workspace/blockbuilder-search-index"
+README_VIS_HOME="/Users/m/workspace/readme-vis"
+cd $README_VIS_HOME
+cp -r $BLOCKBUILDER_SEARCH_INDEX_HOME/data/parsed/ $README_VIS_HOME/data/gist-metadata/input/
+
+cd $README_VIS_HOME/data/scripts
+
+node 01-gists-with-readme.js
+# 21672 README.md files in the d3 gists corpus
+#
+
+node 01b-gists-users.js
+# wrote 29424 gist ID, github username key, value pairs
+# see the results at ../gist-metadata/output/gist-id-to-username.json
+#
+
+node 02-gists-with-readme-with-blocks-link.js
+# 0 gists with unknown users
+# 151 gists with missing files or folders
+# 21672 README.md files in the d3 gists corpus
+# of those README.md files
+# 10847 contain links to bl.ocks.org
+#
+
+node 03a-generate-graph.js
+# 7929 nodes
+# 25824 links
+# in the D3 README graph

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -195,4 +195,4 @@ ls -lAFh
 # now let's call another shell script to generate the 
 # blocks graph metadata
 #
-#sh update-pipeline-blocks-graph.sh
+sh update-pipeline-blocks-graph.sh

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -41,7 +41,13 @@ coffee combine-users.coffee
 # fetch the metadata for all new gists
 # for all known users from the github API
 #
-coffee gist-meta.coffee data/latest-after-20180314.json $UPDATE_AFTER_TIMESTAMP
+#
+# TODO: inside gist-meta script handle case were github 
+# API allocaton runs out before metadata is fetched for all users
+# fixing this is required to run the whole pipeline in sequence, 
+# in autonomous mode
+#
+coffee gist-meta.coffee data/latest-20180314-to-20180820.json $UPDATE_AFTER_TIMESTAMP
 # x-ratelimit-remaining: 4652
 # done with yonester, found 5 gists
 # x-ratelimit-remaining: 4651
@@ -97,20 +103,57 @@ coffee gist-meta.coffee data/latest-after-20180314.json $UPDATE_AFTER_TIMESTAMP
 #
 # let's clone the gists we just found
 #
-coffee gist-cloner.coffee data/latest-after-20180119.json
-# From https://gist.github.com/9893056
+coffee gist-cloner.coffee data/latest-20180314-to-20180820.json
+# From https://gist.github.com/cec274f418b8675efaead3a56a5b324b
 #  * branch            master     -> FETCH_HEAD
 # Already up-to-date.
-# 9893056 zross 0 From https://gist.github.com/9893056
+# cec274f418b8675efaead3a56a5b324b yonicd 0 From https://gist.github.com/cec274f418b8675efaead3a56a5b324b
 #  * branch            master     -> FETCH_HEAD
 #
-# From https://gist.github.com/280cb98c8e49d05181cd
+# From https://gist.github.com/4bc59fca901388ebe4905bdb19af1567
 #  * branch            master     -> FETCH_HEAD
 # Already up-to-date.
-# 280cb98c8e49d05181cd zuzap 0 From https://gist.github.com/280cb98c8e49d05181cd
+# 4bc59fca901388ebe4905bdb19af1567 yonicd 0 From https://gist.github.com/4bc59fca901388ebe4905bdb19af1567
 #  * branch            master     -> FETCH_HEAD
 #
 # done writing files
+# Elasticsearch DEBUG: 2018-08-21T13:14:54Z
+#   starting request { method: 'POST',
+#     path: '/bbindexer/scripts',
+#     body:
+#      { script: 'content',
+#        timeouts: [],
+#        filename: 'data/latest-20180314-to-20180820.json',
+#        ranAt: 2018-08-21T13:14:54.063Z },
+#     query: {} }
+#
+#
+# Elasticsearch TRACE: 2018-08-21T13:14:54Z
+#   -> POST http://localhost:9200/bbindexer/scripts
+#   {
+#     "script": "content",
+#     "timeouts": [],
+#     "filename": "data/latest-20180314-to-20180820.json",
+#     "ranAt": "2018-08-21T13:14:54.063Z"
+#   }
+#   <- 201
+#   {
+#     "_index": "bbindexer",
+#     "_type": "scripts",
+#     "_id": "AWVcn7EAo8z7fxr9sXXS",
+#     "_version": 1,
+#     "_shards": {
+#       "total": 2,
+#       "successful": 1,
+#       "failed": 0
+#     },
+#     "created": true
+#   }
+#
+# Elasticsearch DEBUG: 2018-08-21T13:14:54Z
+#   Request complete
+#
+# indexed
 
 coffee parse.coffee
 # 29325 '6be4e60ab26537300a0f7bf3f050fcf6'

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -4,6 +4,7 @@
 #  1) we have already updated before, and only need to check since the last update date
 #     (which in our case was ~20180120.  we'll get everything since 2018-01-19T00:00:00Z 
 #      to be safe) 
+#  2) we are not worried about validating that users have at least one
 #
 # note: 
 #   each command shows a sample of what the terminal output 
@@ -20,7 +21,15 @@ coffee combine-users.coffee
 # 39 users added from blocksplorer
 # 3506 users total
 
-coffee gist-meta.coffee data/new.json '' 'new-users'
+#
+# optionally get all blocks for new users 
+# for all time
+#
+# TODO implement bash if else to check if 
+# the file data/new.json exists
+# if yes, run this command. if no, do nothing
+#  
+# coffee gist-meta.coffee data/new.json '' 'new-users'
 # combining 3147 with 25277 existing blocks
 # writing 28336 blocks to data/gist-meta.json
 # writing 3147 to data/new.json

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -10,7 +10,10 @@
 #   each command shows a sample of what the terminal output 
 #   should look like if command runs successfully
 
+
 BLOCKBUILDER_SEARCH_INDEX_HOME="/Users/m/workspace/blockbuilder-search-index"
+UPDATE_AFTER_TIMESTAMP="2018-03-14T00:00:00Z"
+
 cd $BLOCKBUILDER_SEARCH_INDEX_HOME
 
 coffee combine-users.coffee
@@ -34,13 +37,62 @@ coffee combine-users.coffee
 # writing 28336 blocks to data/gist-meta.json
 # writing 3147 to data/new.json
 
-coffee gist-meta.coffee data/latest-after-20180119.json 2018-01-19T00:00:00Z
-# x-ratelimit-remaining: 4752
-# done with zuzap, found 1 gists
-# done. number of new gists: 84
-# combining 84 with 29294 existing blocks
-# writing 29327 blocks to data/gist-meta.json
-# writing 84 to data/latest-after-20180119.json
+#
+# fetch the metadata for all new gists
+# for all known users from the github API
+#
+coffee gist-meta.coffee data/latest-after-20180314.json $UPDATE_AFTER_TIMESTAMP
+# x-ratelimit-remaining: 4652
+# done with yonester, found 5 gists
+# x-ratelimit-remaining: 4651
+# x-ratelimit-remaining: undefined
+# done with yifancui, found 34 gists
+# x-ratelimit-remaining: undefined
+# ...
+# done with zzolo, found 0 gists
+# done. number of new gists: 1965
+# combining 1965 with 29327 existing blocks
+# writing 29424 blocks to data/gist-meta.json
+# writing 1965 to data/latest-after-20180314.json
+# Elasticsearch DEBUG: 2018-08-21T12:58:48Z
+#   starting request { method: 'POST',
+#     path: '/bbindexer/scripts',
+#     body:
+#      { script: 'meta',
+#        numBlocks: 1965,
+#        filename: 'data/latest-after-20180314.json',
+#        since: 1970-01-01T00:00:00.000Z,
+#        ranAt: 2018-08-21T12:58:48.304Z },
+#     query: {} }
+#
+#
+# Elasticsearch TRACE: 2018-08-21T12:58:49Z
+#   -> POST http://localhost:9200/bbindexer/scripts
+#   {
+#     "script": "meta",
+#     "numBlocks": 1965,
+#     "filename": "data/latest-after-20180314.json",
+#     "since": "1970-01-01T00:00:00.000Z",
+#     "ranAt": "2018-08-21T12:58:48.304Z"
+#   }
+#   <- 201
+#   {
+#     "_index": "bbindexer",
+#     "_type": "scripts",
+#     "_id": "AWVckPawo8z7fxr9sXXM",
+#     "_version": 1,
+#     "_shards": {
+#       "total": 2,
+#       "successful": 1,
+#       "failed": 0
+#     },
+#     "created": true
+#   }
+#
+# Elasticsearch DEBUG: 2018-08-21T12:58:49Z
+#   Request complete
+#
+# indexed
 
 #
 # let's clone the gists we just found

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -1,0 +1,91 @@
+# here is the log of a d3 blocks metadata update run
+# this log assumes that:
+#
+#  1) we don't have any new github usernames to check
+#  2) we have already updated before, and only need to check since the last update date
+#     (which in our case was ~20180120.  we'll get everything since 2018-01-19T00:00:00Z 
+#      to be safe) 
+#
+# note: 
+#   each command shows a sample of what the terminal output 
+#   should look like if command runs successfully
+
+BLOCKBUILDER_SEARCH_INDEX_HOME="~/workspace/blockbuilder-search-index"
+cd $BLOCKBUILDER_SEARCH_INDEX_HOME
+
+coffee combine-users.coffee
+# 205 users from blocks links in SO
+# 468 users from blocks links in knight course
+# 2594 users added from bb
+# 200 added from manual list of users
+# 35 users added from blocksplorer
+# 3502 users total
+
+coffee gist-meta.coffee data/new.json '' 'new-users'
+# combining 3147 with 25277 existing blocks
+# writing 28336 blocks to data/gist-meta.json
+# writing 3147 to data/new.json
+
+coffee gist-meta.coffee data/latest-after-20180119.json 2018-01-19T00:00:00Z
+# x-ratelimit-remaining: 4752
+# done with zuzap, found 1 gists
+# done. number of new gists: 84
+# combining 84 with 29294 existing blocks
+# writing 29327 blocks to data/gist-meta.json
+# writing 84 to data/latest-after-20180119.json
+
+#
+# let's clone the gists we just found
+#
+coffee gist-cloner.coffee data/latest-after-20180119.json
+# From https://gist.github.com/9893056
+#  * branch            master     -> FETCH_HEAD
+# Already up-to-date.
+# 9893056 zross 0 From https://gist.github.com/9893056
+#  * branch            master     -> FETCH_HEAD
+#
+# From https://gist.github.com/280cb98c8e49d05181cd
+#  * branch            master     -> FETCH_HEAD
+# Already up-to-date.
+# 280cb98c8e49d05181cd zuzap 0 From https://gist.github.com/280cb98c8e49d05181cd
+#  * branch            master     -> FETCH_HEAD
+#
+# done writing files
+
+coffee parse.coffee
+# 29325 '6be4e60ab26537300a0f7bf3f050fcf6'
+# 29326 'c46227f4e38216113d7635c8b215d3b0'
+# 29327 '05261d94df1e95a02a0a5cd1076803f5'
+# done
+# skipped 0 missing files
+# wrote 10445 API blocks
+# wrote 11522 Color blocks
+# wrote 117120 Files blocks
+# wrote 29327 total blocks
+
+cd data/parsed
+pwd
+# /Users/m/workspace/blockbuilder-search-index/data/parsed
+
+#
+# tada, we have some fresh blocks metadata files
+#
+ls -lAFh
+# total 285576
+# -rw-r--r--  1 m  staff     2B Mar 16 17:57 apis.json
+# -rw-r--r--  1 m  staff   3.2M Mar 16 17:57 blocks-api.json
+# -rw-r--r--  1 m  staff   2.2M Mar 16 17:57 blocks-colors-min.json
+# -rw-r--r--  1 m  staff   4.2M Mar 16 17:57 blocks-colors.json
+# -rw-r--r--  1 m  staff   5.9M Mar 16 17:57 blocks-min.json
+# -rw-r--r--  1 m  staff    75M Mar 16 17:57 blocks.json
+# -rw-r--r--  1 m  staff     2B Mar 16 17:57 colors.json
+# -rw-r--r--  1 m  staff    45M Mar 16 17:57 files-blocks.json
+# -rw-r--r--  1 m  staff    10B Mar 16 17:57 libs.csv
+# -rw-r--r--  1 m  staff    13B Mar 16 17:57 modules.csv
+# -rw-r--r--  1 m  staff   3.6M Aug 14  2017 readme-blocks-graph.json
+
+#
+# now let's call another shell script to generate the 
+# blocks graph metadata
+#
+#sh update-pipeline-blocks-graph.sh

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -156,15 +156,18 @@ coffee gist-cloner.coffee data/latest-20180314-to-20180820.json
 # indexed
 
 coffee parse.coffee
-# 29325 '6be4e60ab26537300a0f7bf3f050fcf6'
-# 29326 'c46227f4e38216113d7635c8b215d3b0'
-# 29327 '05261d94df1e95a02a0a5cd1076803f5'
+# 29419 'a488e022362571a9e1187985df7f47a4'
+# 29420 '8d331f9b5c7dd57908de0db3439ab7ab'
+# 29421 'd1dbded3fe2c8cb94b207904c7c4c73d'
+# 29422 '5b7d24613149e60867c2bf6fe097c587'
+# 29423 '492182b66a0d1a3dd5513ff5b71c900c'
+# 29424 '056046c1f83e3926484bd2e21847341e'
 # done
 # skipped 0 missing files
 # wrote 10445 API blocks
 # wrote 11522 Color blocks
-# wrote 117120 Files blocks
-# wrote 29327 total blocks
+# wrote 117533 Files blocks
+# wrote 29424 total blocks
 
 cd data/parsed
 pwd
@@ -174,17 +177,18 @@ pwd
 # tada, we have some fresh blocks metadata files
 #
 ls -lAFh
-# total 285576
-# -rw-r--r--  1 m  staff     2B Mar 16 17:57 apis.json
-# -rw-r--r--  1 m  staff   3.2M Mar 16 17:57 blocks-api.json
-# -rw-r--r--  1 m  staff   2.2M Mar 16 17:57 blocks-colors-min.json
-# -rw-r--r--  1 m  staff   4.2M Mar 16 17:57 blocks-colors.json
-# -rw-r--r--  1 m  staff   5.9M Mar 16 17:57 blocks-min.json
-# -rw-r--r--  1 m  staff    75M Mar 16 17:57 blocks.json
-# -rw-r--r--  1 m  staff     2B Mar 16 17:57 colors.json
-# -rw-r--r--  1 m  staff    45M Mar 16 17:57 files-blocks.json
-# -rw-r--r--  1 m  staff    10B Mar 16 17:57 libs.csv
-# -rw-r--r--  1 m  staff    13B Mar 16 17:57 modules.csv
+# total 286816
+# -rw-r--r--@ 1 m  staff   6.0K Mar 16 18:10 .DS_Store
+# -rw-r--r--  1 m  staff     2B Aug 21 06:29 apis.json
+# -rw-r--r--  1 m  staff   3.2M Aug 21 06:29 blocks-api.json
+# -rw-r--r--  1 m  staff   2.2M Aug 21 06:29 blocks-colors-min.json
+# -rw-r--r--  1 m  staff   4.2M Aug 21 06:29 blocks-colors.json
+# -rw-r--r--  1 m  staff   5.9M Aug 21 06:29 blocks-min.json
+# -rw-r--r--  1 m  staff    76M Aug 21 06:29 blocks.json
+# -rw-r--r--  1 m  staff     2B Aug 21 06:29 colors.json
+# -rw-r--r--  1 m  staff    45M Aug 21 06:29 files-blocks.json
+# -rw-r--r--  1 m  staff    10B Aug 21 06:29 libs.csv
+# -rw-r--r--  1 m  staff    13B Aug 21 06:29 modules.csv
 # -rw-r--r--  1 m  staff   3.6M Aug 14  2017 readme-blocks-graph.json
 
 #

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -1,8 +1,7 @@
 # here is the log of a d3 blocks metadata update run
 # this log assumes that:
 #
-#  1) we don't have any new github usernames to check
-#  2) we have already updated before, and only need to check since the last update date
+#  1) we have already updated before, and only need to check since the last update date
 #     (which in our case was ~20180120.  we'll get everything since 2018-01-19T00:00:00Z 
 #      to be safe) 
 #
@@ -18,8 +17,8 @@ coffee combine-users.coffee
 # 468 users from blocks links in knight course
 # 2594 users added from bb
 # 200 added from manual list of users
-# 35 users added from blocksplorer
-# 3502 users total
+# 39 users added from blocksplorer
+# 3506 users total
 
 coffee gist-meta.coffee data/new.json '' 'new-users'
 # combining 3147 with 25277 existing blocks

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -10,7 +10,7 @@
 #   each command shows a sample of what the terminal output 
 #   should look like if command runs successfully
 
-BLOCKBUILDER_SEARCH_INDEX_HOME="~/workspace/blockbuilder-search-index"
+BLOCKBUILDER_SEARCH_INDEX_HOME="/Users/m/workspace/blockbuilder-search-index"
 cd $BLOCKBUILDER_SEARCH_INDEX_HOME
 
 coffee combine-users.coffee


### PR DESCRIPTION
This PR adds an update script that can be run from beginning to end, to update a local search index with:
- newly created blocks from known users
-  all blocks old and new from newly discovered users.

💡 the idea behind this PR is to take the logs from [this update log wiki page](https://github.com/enjalot/blockbuilder-search-index/wiki/update-log-20180316.md) and make scripts that can be more easily run in the future