### PR TITLE
improve regex that we use to detect d3 modules in script tags in index.html files

### DIFF
--- a/parse.coffee
+++ b/parse.coffee
@@ -182,7 +182,7 @@ pruneFiles = (gist) ->
 
 parseD3Functions = (code) ->
   # we match d3.foo.bar( which will find plugins and unofficial api functions
-  re = new RegExp(/d3\.[a-zA-Z0-9\.]*?\(/g)
+  re = new RegExp(/(d3-[\w-]*)(?=\.)/g)
   matches = code.match(re) or []
   return matches
 


### PR DESCRIPTION
This PR improves the regex that we use to detect d3 modules in script tags in index.html files

```javascript
/(d3-[\w-]*)(?=\.)/
```

https://regexr.com/

![screen shot 2018-08-26 at 1 13 09 am](https://user-images.githubusercontent.com/2119400/44626192-3f62c600-a8cd-11e8-9965-b81920f24540.png)