### PR TITLE
parse out d3v5 version

### DIFF
--- a/parse.coffee
+++ b/parse.coffee
@@ -266,7 +266,9 @@ parseD3Version = (code) ->
   scripts = parseScriptTags(code)
   version = "NA"
   scripts.forEach (script) ->
-    if script.indexOf("d3.v4") >= 0
+    if script.indexOf("d3.v5") >= 0
+      version = "v5"
+    else if script.indexOf("d3.v4") >= 0
       version = "v4"
     else if script.indexOf("d3/3.") >= 0 or script.indexOf("d3.v3") >= 0
       version = "v3"


### PR DESCRIPTION
This PR parses out d3v5 versions from gists

the backend piece needed for frontend PR https://github.com/enjalot/blockbuilder-search/pull/76

fix #63